### PR TITLE
node.c: Use stored offset for level 2 node reference list on ReFS 3.14+

### DIFF
--- a/librefs/node.c
+++ b/librefs/node.c
@@ -2620,7 +2620,13 @@ static int refs_node_parse_level1_block_level2_node_reference_list(
 			block_size,
 			&block[node_reference_list_offset + sizeof(le32) * 2],
 			node_reference_list_inset - sizeof(le32));
-		offset += node_reference_list_inset;
+
+		/* The stored value is the absolute (block-relative) offset
+		 * where the node reference list actually starts; use it
+		 * directly instead of assuming a fixed 5-element inset, which
+		 * is wrong for at least some 3.14 volumes (observed: stored
+		 * start offset was 2 elements past the fixed inset). */
+		offset = level2_block_list_start;
 	}
 
 	err = sys_malloc((size_t) node_reference_list_size,


### PR DESCRIPTION

## Problem

`refs-fuse` fails to mount a ReFS 3.14 volume created by Windows Server:

```
First level 2 node reference offset precedes end of node reference offsets list: 72 < 280
No primary/secondary level 2 blocks parsed!
```

## Cause

In `refs_node_parse_level1_block_level2_node_reference_list()`, when the level 1
block carries a node reference offsets list, the code steps past that list using
a hardcoded inset:

```c
node_reference_list_inset = 5 * sizeof(le32);
...
offset += node_reference_list_inset;
```

This assumes the list always holds exactly 5 elements. The block also stores the
absolute, block-relative offset at which the node reference list starts, already
read a few lines earlier as `level2_block_list_start`. On this volume the two
disagree: the stored start is 280, while the fixed 20-byte inset lands at 72,
two elements short. The first two values read are then garbage (72, 0) instead
of the real first offset (280), and parsing gives up.

## Fix

Use the stored offset directly rather than inferring it.

## Alternative considered

The hardcoded `5` could instead be replaced with the list's actual element
count, preserving the arithmetic form. I went with the stored offset because it
is authoritative and already being read, so it does not depend on deriving a
count correctly. If you would rather have the counted form, or want both (derive
the count and warn when it disagrees with the stored offset, which would surface
layout surprises rather than hide them), I am happy to rework it.

## Testing

- 20 GB ReFS 3.14 volume created by Windows Server over iSCSI, GPT partitioned,
  4096-byte clusters, 16384-byte metadata blocks.
- Before: mount fails as above. After: `refs-fuse` mounts read-only,
  `refsls -a -l -R` lists 2957 entries, and file contents read back correctly.
- No behaviour change on the path where `node_reference_list_inset` is zero.

## Caveat

I have only one 3.14 volume to test against, so I cannot tell whether the fixed
inset was correct for some other layout or simply never exercised. On any volume
where the stored offset and the fixed inset agree, this change is a no-op.
