### PR TITLE
node.c: Select the newest valid level 1 block on ReFS 3.14+

### DIFF
--- a/librefs/Makefile.am
+++ b/librefs/Makefile.am
@@ -30,6 +30,8 @@ librefs_la_LDFLAGS  = \
 librefs_la_LIBADD  = \
 	$(COMMON_LIBS)
 librefs_la_SOURCES = \
+	crc.c \
+	crc.h \
 	fsapi.c \
 	node.c \
 	rb_tree.c \

--- a/librefs/crc.c
+++ b/librefs/crc.c
@@ -1,0 +1,54 @@
+/*-
+ * crc.c - ReFS metadata checksum definitions.
+ *
+ * Copyright (c) 2025 Erik Larsson
+ *
+ * This program/include file is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program/include file is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program (in the main directory of the source
+ * distribution in the file COPYING); if not, write to the Free Software
+ * Foundation,Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "crc.h"
+
+/* Reflected polynomial, matching the reflected input/output form that ReFS
+ * uses: CRC-32C 0x1EDC6F41 reflected -> 0x82F63B78, with an all-ones initial
+ * value and an all-ones final XOR. */
+#define REFS_CRC32C_POLY 0x82F63B78U
+
+/* This is deliberately the simple bitwise formulation. It is only used to
+ * validate a bounded number of blocks while selecting a checkpoint, so the
+ * table-driven variant is not worth the space here. If checksum verification
+ * is ever extended to every block read, revisit this. */
+
+u32 refs_crc32c(u32 crc, const void *const data, const size_t size)
+{
+	const u8 *const p = (const u8*) data;
+
+	u32 c = ~crc;
+	size_t i = 0;
+	int k = 0;
+
+	for(i = 0; i < size; ++i) {
+		c ^= p[i];
+		for(k = 0; k < 8; ++k) {
+			c = (c & 1) ? ((c >> 1) ^ REFS_CRC32C_POLY) : (c >> 1);
+		}
+	}
+
+	return ~c;
+}

--- a/librefs/crc.h
+++ b/librefs/crc.h
@@ -1,0 +1,61 @@
+/*-
+ * crc.h - ReFS metadata checksum declarations.
+ *
+ * Copyright (c) 2025 Erik Larsson
+ *
+ * This program/include file is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program/include file is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program (in the main directory of the source
+ * distribution in the file COPYING); if not, write to the Free Software
+ * Foundation,Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _REFS_CRC_H
+#define _REFS_CRC_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "sys.h"
+
+/**
+ * The checksum type stored in a node reference's checksum descriptor.
+ *
+ * The type is carried in bits 16-23 of the 64-bit field that this code
+ * reads as the reference's 'flags', for both v1 and v3 references.
+ *
+ * Type 2 (CRC-64/NVME) is used by the level 2 and higher blocks, whose
+ * checksums are stored in the referencing parent. Nothing verifies those
+ * yet, so no CRC-64 implementation is provided here.
+ */
+#define REFS_CHECKSUM_TYPE_CRC32C 1
+
+#define REFS_CHECKSUM_TYPE_FROM_FLAGS(flags) \
+	((u8) (((flags) >> 16) & 0xFFU))
+
+/**
+ * Compute a CRC-32C (Castagnoli) checksum.
+ *
+ * Follows the zlib convention: pass 0 as @crc to start a new checksum and
+ * the previous return value to continue one, so that a checksum can be
+ * computed over discontiguous pieces.
+ *
+ * @param crc the running checksum, or 0 to start a new one.
+ * @param data the data to checksum.
+ * @param size the size of @p data in bytes.
+ *
+ * @return the updated checksum.
+ */
+u32 refs_crc32c(u32 crc, const void *data, size_t size);
+
+#endif /* !defined(_REFS_CRC_H) */

--- a/librefs/node.c
+++ b/librefs/node.c
@@ -25,6 +25,7 @@
 
 #include "node.h"
 
+#include "crc.h"
 #include "rb_tree.h"
 #include "layout.h"
 #include "util.h"
@@ -32,6 +33,13 @@
 
 
 /* Macros. */
+
+/* The on-disk size of a version 3 node reference. The fields that checksum
+ * verification reads (the flags at offset 32 and the checksum value at offset
+ * 40) occupy the last 16 bytes, so this is both the amount that must be zeroed
+ * when recomputing a block's self checksum and the minimum that must be
+ * present for the reference to be readable at all. */
+#define REFS_V3_NODE_REFERENCE_SIZE 48
 
 #define emit_entry_header(prefix, indent, title, entry_index, num_entries, \
 		entry_offset, type) \
@@ -2646,6 +2654,72 @@ out:
 	return err;
 }
 
+/**
+ * Compute the self checksum of a block that carries a self reference.
+ *
+ * The blocks that carry a self reference (the superblock and the level 1 /
+ * checkpoint blocks) store the checksum of their own first cluster,
+ * computed with the bytes of the self reference itself zeroed out. Blocks
+ * from level 2 and up have no self reference at all; their checksum is
+ * stored in the referencing parent instead.
+ *
+ * Note that the checksummed range is the first cluster of the block rather
+ * than the whole block. This has so far only been observed on volumes with
+ * a 4096-byte cluster size.
+ *
+ * @return SYS_TRUE if a checksum was computed, SYS_FALSE if this block's
+ *         checksum cannot be reproduced (unknown checksum type, or a self
+ *         reference that does not lie inside the checksummed range).
+ */
+static sys_bool refs_node_compute_self_checksum(
+		const u8 *const block,
+		const u32 block_size,
+		const u32 cluster_size,
+		const u32 self_reference_offset,
+		const u32 self_reference_size,
+		const u8 checksum_type,
+		u64 *const out_checksum)
+{
+	static const u8 zeroes[REFS_V3_NODE_REFERENCE_SIZE] = { 0 };
+
+	const u32 checksummed_size = sys_min(cluster_size, block_size);
+
+	u32 tail_offset = 0;
+	u32 crc = 0;
+
+	/* The checksummed range has only been confirmed on volumes with a
+	 * 4096-byte cluster size, where it is the first cluster of the block.
+	 * Whether a larger cluster size widens the range or keeps it at 4096 is
+	 * unknown, and guessing wrong would reject an intact block, so decline
+	 * to verify rather than risk failing a mountable volume. */
+	if(cluster_size != 4096) {
+		return SYS_FALSE;
+	}
+
+	if(!self_reference_size || self_reference_size > sizeof(zeroes) ||
+		self_reference_offset >= checksummed_size ||
+		self_reference_size >
+		checksummed_size - self_reference_offset)
+	{
+		return SYS_FALSE;
+	}
+
+	if(checksum_type != REFS_CHECKSUM_TYPE_CRC32C) {
+		return SYS_FALSE;
+	}
+
+	tail_offset = self_reference_offset + self_reference_size;
+
+	crc = refs_crc32c(crc, block, self_reference_offset);
+	crc = refs_crc32c(crc, zeroes, self_reference_size);
+	crc = refs_crc32c(crc, &block[tail_offset],
+		checksummed_size - tail_offset);
+
+	*out_checksum = crc;
+
+	return SYS_TRUE;
+}
+
 static int refs_node_parse_level1_block(
 		refs_node_crawl_context *const context,
 		refs_node_walk_visitor *const visitor,
@@ -2656,7 +2730,9 @@ static int refs_node_parse_level1_block(
 		const u32 block_size,
 		refs_node_block_queue_element **const
 		out_level2_node_references,
-		size_t *const out_level2_node_references_count)
+		size_t *const out_level2_node_references_count,
+		u64 *const out_checkpoint_number,
+		sys_bool *const out_checksum_valid)
 {
 	static const char *const prefix = "\t";
 	static const size_t indent = 0;
@@ -2723,6 +2799,75 @@ static int refs_node_parse_level1_block(
 		PRAu64(self_reference_size));
 	print_le64_dechex("Checkpoint number", prefix, indent, block,
 		&header[0x40]);
+	if(out_checkpoint_number) {
+		*out_checkpoint_number = read_le64(&header[0x40]);
+	}
+
+	if(out_checksum_valid) {
+		/* A block whose checksum we cannot reproduce is reported as
+		 * valid: we only want to reject blocks that we have positively
+		 * determined to be damaged. */
+		*out_checksum_valid = SYS_TRUE;
+
+		/* The checksum layout has only been confirmed against version
+		 * 3 volumes. Verifying a version 1 volume with the wrong rules
+		 * would reject both level 1 blocks and turn a mountable volume
+		 * into an unmountable one, so leave those unverified. */
+		if(is_v3 && self_reference_offset <= block_size &&
+			REFS_V3_NODE_REFERENCE_SIZE <=
+			block_size - self_reference_offset)
+		{
+			const u8 *const self_reference =
+				&block[self_reference_offset];
+			const u64 reference_flags =
+				read_le64(&self_reference[32]);
+			const u8 checksum_type =
+				REFS_CHECKSUM_TYPE_FROM_FLAGS(reference_flags);
+			const u64 stored_checksum =
+				read_le64(&self_reference[40]);
+
+			u64 computed_checksum = 0;
+
+			if(!refs_node_compute_self_checksum(
+				/* const u8 *block */
+				block,
+				/* u32 block_size */
+				block_size,
+				/* u32 cluster_size */
+				context->cluster_size,
+				/* u32 self_reference_offset */
+				self_reference_offset,
+				/* u32 self_reference_size */
+				self_reference_size,
+				/* u8 checksum_type */
+				checksum_type,
+				/* u64 *out_checksum */
+				&computed_checksum))
+			{
+				sys_log_debug("Unable to verify the checksum of "
+					"level 1 block %" PRIu64 " (checksum "
+					"type %" PRIu32 ").",
+					PRAu64(block_number),
+					PRAu32((u32) checksum_type));
+			}
+			else if((u32) computed_checksum !=
+				(u32) stored_checksum)
+			{
+				/* Only the low 32 bits are meaningful; the
+				 * stored value always occupies a 64-bit
+				 * field. */
+				sys_log_warning("Checksum mismatch in level 1 "
+					"block %" PRIu64 ": computed "
+					"0x%" PRIX64 " but expected "
+					"0x%" PRIX64 ".",
+					PRAu64(block_number),
+					PRAX64(computed_checksum),
+					PRAX64(stored_checksum &
+					0xFFFFFFFFU));
+				*out_checksum_valid = SYS_FALSE;
+			}
+		}
+	}
 	print_le64_dechex("First checkpoint number (?)", prefix, indent, block,
 		&header[0x48]);
 	print_unknown32(prefix, indent, block, &header[0x50]);
@@ -11169,6 +11314,17 @@ static int refs_node_crawl_volume_metadata(
 	size_t primary_level2_blocks_count = 0;
 	refs_node_block_queue_element *secondary_level2_blocks = NULL;
 	size_t secondary_level2_blocks_count = 0;
+	refs_node_block_queue_element *chosen_level2_blocks = NULL;
+	size_t chosen_level2_blocks_count = 0;
+	int primary_err = 0;
+	int secondary_err = 0;
+	u64 primary_checkpoint_number = 0;
+	u64 secondary_checkpoint_number = 0;
+	sys_bool primary_checksum_valid = SYS_FALSE;
+	sys_bool secondary_checksum_valid = SYS_FALSE;
+	sys_bool primary_usable = SYS_FALSE;
+	sys_bool secondary_usable = SYS_FALSE;
+	sys_bool use_primary = SYS_TRUE;
 	refs_node_block_queue level2_queue;
 	refs_node_block_queue level3_queue;
 	size_t i = 0;
@@ -11386,10 +11542,13 @@ static int refs_node_crawl_volume_metadata(
 				/* u8 **out_data */
 				&block);
 			if(err) {
-				goto out;
+				sys_log_pwarning(err, "Error while reading "
+					"primary level 1 block %" PRIu64,
+					PRAu64(primary_level1_block));
+				primary_err = err;
+				err = 0;
 			}
-
-			if(primary_level1_node) {
+			else if(primary_level1_node) {
 				u8 *new_block = NULL;
 
 				err = sys_malloc(block_allocated_size,
@@ -11404,28 +11563,39 @@ static int refs_node_crawl_volume_metadata(
 			}
 		}
 
-		err = refs_node_parse_level1_block(
-			/* refs_node_crawl_context *context */
-			&crawl_context,
-			/* refs_node_walk_visitor *visitor */
-			visitor,
-			/* u64 block_number */
-			primary_level1_block,
-			/* u64 cluster_number */
-			primary_level1_block,
-			/* u64 block_queue_index */
-			0,
-			/* const u8 *block */
-			(primary_level1_node && *primary_level1_node) ?
-			(const u8*) *primary_level1_node : block,
-			/* u32 block_size */
-			block_size,
-			/* refs_node_block_queue_element **out_level2_extents */
-			&primary_level2_blocks,
-			/* size_t *out_level2_extents_count */
-			&primary_level2_blocks_count);
-		if(err) {
-			goto out;
+		if(!primary_err) {
+			err = refs_node_parse_level1_block(
+				/* refs_node_crawl_context *context */
+				&crawl_context,
+				/* refs_node_walk_visitor *visitor */
+				visitor,
+				/* u64 block_number */
+				primary_level1_block,
+				/* u64 cluster_number */
+				primary_level1_block,
+				/* u64 block_queue_index */
+				0,
+				/* const u8 *block */
+				(primary_level1_node && *primary_level1_node) ?
+				(const u8*) *primary_level1_node : block,
+				/* u32 block_size */
+				block_size,
+				/* refs_node_block_queue_element
+				 * **out_level2_extents */
+				&primary_level2_blocks,
+				/* size_t *out_level2_extents_count */
+				&primary_level2_blocks_count,
+				/* u64 *out_checkpoint_number */
+				&primary_checkpoint_number,
+				/* sys_bool *out_checksum_valid */
+				&primary_checksum_valid);
+			if(err) {
+				sys_log_pwarning(err, "Error while parsing "
+					"primary level 1 block %" PRIu64,
+					PRAu64(primary_level1_block));
+				primary_err = err;
+				err = 0;
+			}
 		}
 	}
 
@@ -11456,10 +11626,13 @@ static int refs_node_crawl_volume_metadata(
 				/* u8 **out_data */
 				&block);
 			if(err) {
-				goto out;
+				sys_log_pwarning(err, "Error while reading "
+					"secondary level 1 block %" PRIu64,
+					PRAu64(secondary_level1_block));
+				secondary_err = err;
+				err = 0;
 			}
-
-			if(secondary_level1_node) {
+			else if(secondary_level1_node) {
 				u8 *new_block = NULL;
 
 				err = sys_malloc(block_allocated_size,
@@ -11474,47 +11647,111 @@ static int refs_node_crawl_volume_metadata(
 			}
 		}
 
-		err = refs_node_parse_level1_block(
-			/* refs_node_crawl_context *context */
-			&crawl_context,
-			/* refs_node_walk_visitor *visitor */
-			visitor,
-			/* u64 cluster_number */
-			primary_level1_block,
-			/* u64 block_number */
-			secondary_level1_block,
-			/* u64 block_queue_index */
-			1,
-			/* const u8 *block */
-			(secondary_level1_node && *secondary_level1_node) ?
-			(const u8*) *secondary_level1_node : block,
-			/* u32 block_size */
-			block_size,
-			/* refs_node_block_queue_element **out_level2_extents */
-			&secondary_level2_blocks,
-			/* size_t *out_level2_extents_count */
-			&secondary_level2_blocks_count);
-		if(err) {
-			goto out;
+		if(!secondary_err) {
+			err = refs_node_parse_level1_block(
+				/* refs_node_crawl_context *context */
+				&crawl_context,
+				/* refs_node_walk_visitor *visitor */
+				visitor,
+				/* u64 cluster_number */
+				primary_level1_block,
+				/* u64 block_number */
+				secondary_level1_block,
+				/* u64 block_queue_index */
+				1,
+				/* const u8 *block */
+				(secondary_level1_node &&
+				*secondary_level1_node) ?
+				(const u8*) *secondary_level1_node : block,
+				/* u32 block_size */
+				block_size,
+				/* refs_node_block_queue_element
+				 * **out_level2_extents */
+				&secondary_level2_blocks,
+				/* size_t *out_level2_extents_count */
+				&secondary_level2_blocks_count,
+				/* u64 *out_checkpoint_number */
+				&secondary_checkpoint_number,
+				/* sys_bool *out_checksum_valid */
+				&secondary_checksum_valid);
+			if(err) {
+				sys_log_pwarning(err, "Error while parsing "
+					"secondary level 1 block %" PRIu64,
+					PRAu64(secondary_level1_block));
+				secondary_err = err;
+				err = 0;
+			}
 		}
 	}
 
-	if(!primary_level2_blocks || !secondary_level2_blocks) {
-		sys_log_critical("No %s%s%s level 2 blocks parsed!",
-			!primary_level2_blocks ? "primary" : "",
-			(!primary_level2_blocks && !secondary_level2_blocks) ?
-				"/" : "",
-			!secondary_level2_blocks ? "secondary" : "");
-		err = EINVAL;
+	/* A checkpoint is usable if it was read and parsed and its checksum
+	 * either validated or could not be computed at all. The two level 1
+	 * blocks hold alternating generations of the filesystem rather than
+	 * two copies of one generation, so the usable one with the highest
+	 * checkpoint number is the most recent committed state. Falling back
+	 * to the older generation is what allows a volume that was not
+	 * cleanly unmounted to be mounted at all. */
+	primary_usable = (!primary_err && primary_level2_blocks &&
+		primary_checksum_valid) ? SYS_TRUE : SYS_FALSE;
+	secondary_usable = (!secondary_err && secondary_level2_blocks &&
+		secondary_checksum_valid) ? SYS_TRUE : SYS_FALSE;
+
+	if(!primary_usable && !secondary_usable) {
+		sys_log_critical("Neither the primary nor the secondary level "
+			"1 block is usable. The volume is too damaged to "
+			"mount.");
+		err = primary_err ? primary_err :
+			(secondary_err ? secondary_err : EINVAL);
 		goto out;
 	}
+	else if(!primary_usable || !secondary_usable) {
+		use_primary = primary_usable;
+		sys_log_warning("The %s level 1 block is unusable, mounting "
+			"from the %s block (checkpoint %" PRIu64 "). The "
+			"volume was not cleanly unmounted and this view of it "
+			"may be out of date.",
+			primary_usable ? "secondary" : "primary",
+			primary_usable ? "primary" : "secondary",
+			PRAu64(use_primary ? primary_checkpoint_number :
+			secondary_checkpoint_number));
+	}
+	else if(primary_checkpoint_number == secondary_checkpoint_number) {
+		/* The two level 1 blocks hold successive checkpoints, so equal
+		 * checkpoint numbers are not a state that should occur. Say so
+		 * rather than silently reinstating the unconditional preference
+		 * for the primary block that this selection exists to replace.
+		 */
+		sys_log_warning("Both level 1 blocks report checkpoint "
+			"%" PRIu64 ". This is unexpected; proceeding with the "
+			"primary block.",
+			PRAu64(primary_checkpoint_number));
+		use_primary = SYS_TRUE;
+	}
+	else {
+		use_primary = (primary_checkpoint_number >
+			secondary_checkpoint_number) ? SYS_TRUE : SYS_FALSE;
+	}
 
-	if(primary_level2_blocks_count != secondary_level2_blocks_count) {
+	if(use_primary) {
+		chosen_level2_blocks = primary_level2_blocks;
+		chosen_level2_blocks_count = primary_level2_blocks_count;
+	}
+	else {
+		chosen_level2_blocks = secondary_level2_blocks;
+		chosen_level2_blocks_count = secondary_level2_blocks_count;
+	}
+
+	if(!primary_usable || !secondary_usable) {
+		/* Only one generation was parsed, so there is nothing to
+		 * compare it against. */
+	}
+	else if(primary_level2_blocks_count != secondary_level2_blocks_count) {
 		sys_log_warning("Mismatching level 2 block count in "
 			"level 1 blocks: %" PRIu32 " != %" PRIu32 " "
-			"Proceeding with primary...",
+			"Proceeding with %s...",
 			PRAu32(primary_level2_blocks_count),
-			PRAu32(secondary_level2_blocks_count));
+			PRAu32(secondary_level2_blocks_count),
+			use_primary ? "primary" : "secondary");
 	}
 	else {
 		refs_node_block_queue_element *cur_primary =
@@ -11546,24 +11783,34 @@ static int refs_node_crawl_volume_metadata(
 		else if(!mismatch);
 		else if(block_map && *block_map) {
 			sys_log_debug("Mismatching level 2 block data in "
-				"level 1 blocks. Proceeding with primary...");
+				"level 1 blocks. Proceeding with %s...",
+				use_primary ? "primary" : "secondary");
 		}
 		else {
 			sys_log_warning("Mismatching level 2 block data in "
-				"level 1 blocks. Proceeding with primary...");
+				"level 1 blocks. Proceeding with %s...",
+				use_primary ? "primary" : "secondary");
 		}
 	}
 
-	level2_queue.queue = primary_level2_blocks;
+	level2_queue.queue = chosen_level2_blocks;
 	/* Find the tail. */
-	level2_queue.queue_tail = primary_level2_blocks;
+	level2_queue.queue_tail = chosen_level2_blocks;
 	while(level2_queue.queue_tail->next) {
 		level2_queue.queue_tail = level2_queue.queue_tail->next;
 	}
-	level2_queue.block_queue_length = primary_level2_blocks_count;
+	level2_queue.block_queue_length = chosen_level2_blocks_count;
 
-	primary_level2_blocks = NULL;
-	primary_level2_blocks_count = 0;
+	/* Ownership of the chosen list has moved to the queue. The list that
+	 * was not chosen is still owned here and released via 'out'. */
+	if(use_primary) {
+		primary_level2_blocks = NULL;
+		primary_level2_blocks_count = 0;
+	}
+	else {
+		secondary_level2_blocks = NULL;
+		secondary_level2_blocks_count = 0;
+	}
 
 	if(block_map && *block_map) {
 		mappings = *block_map;


### PR DESCRIPTION

## Problem

Two issues in `refs_node_crawl_volume_metadata()`:

1. When the two level 1 blocks disagree, it always proceeds with the primary,
   with no recency or integrity check.
2. It aborts the entire mount if either level 1 block fails to parse.

The two level 1 (checkpoint) blocks hold successive generations of the metadata
tree. On my volume the superblock lists primary = 52300 and secondary = 627208,
with checkpoint numbers 104 and 103 respectively; an earlier capture of block
52300 held checkpoint 40. So the newest generation is not reliably in the
primary slot, and preferring it unconditionally can silently present a
filesystem that is a generation out of date, with no warning and no corruption.

I want to be careful about how far I push that: I have three data points across
two slots, not a controlled write sequence. What I can state firmly is that the
primary slot is not guaranteed to hold the newest checkpoint. Whether the slots
strictly alternate is a hypothesis I have not confirmed, and the change does not
depend on it being true.

Separately, aborting on a single unparseable block makes a volume unmountable
even when the other generation is completely intact, which is precisely the
situation where a read-only tool is most valuable.

## Checksums

Verifying a checkpoint requires knowing the checksum format, which as far as I
can see is not implemented (the `CRC32C` and `CRC64` strings in node.c are
display labels in print functions; nothing is computed or compared). I derived
it empirically.

Blocks carrying a self reference (`SUPB`, `CHKP`), checksum type 1:

```
CRC-32C (poly 0x1EDC6F41 reflected, init and xorout all ones)
  over block[0 .. cluster_size]            <- 4096, not the full 16384
  with the entire self reference zeroed
```

Level 2 and above (`MSB+`), checksum type 2, stored in the referencing parent
rather than in the block itself:

```
CRC-64/NVME (poly 0xAD93D23594C93659 reflected, init and xorout all ones)
  over the full block, unmodified
```

The checksum type is carried in bits 16-23 of the 64-bit field this code reads
as a node reference's flags, for both v1 and v3 references.

Validation: exact matches on 2 level 1 blocks, 3 superblocks and 3 level 2
blocks, plus a historical capture of one level 1 block with different content
and a different stored checksum, which acts as an independent temporal sample.
Of 16384 candidate lengths across 5 zeroing variants, exactly one combination
matched. The CRC-32C implementation was validated against the RFC 3720 vectors
and returns the standard check value 0xE3069283 for "123456789".

Only CRC-32C is implemented in this change, since only the level 1 self
checksums are verified. CRC-64 would be required to verify the tree itself.

## Change

- Parse both level 1 blocks independently, tolerating one that fails.
- Verify each block's CRC-32C self checksum.
- Use the higher checkpoint number among the blocks that pass.
- Fall back to the older generation, with a warning, when the newer one is
  damaged.
- Fail only when neither block is usable.

This is the usual copy-on-write recovery model, comparable to ZFS uberblock or
Btrfs superblock selection. ReFS has no write-ahead log to replay.

## Deliberately conservative

Verification is gated to version 3 volumes with a 4096-byte cluster size, the
only combination I have observed. Anywhere else the block is left unverified
rather than risk applying the wrong rules, rejecting both level 1 blocks, and
turning a mountable volume into an unmountable one. For the same reason, a block
whose checksum cannot be reproduced is treated as valid: only blocks positively
determined to be damaged are rejected.

## What this does not do

A passing self checksum shows that the checkpoint block itself is intact. It
does not show that every block it references was flushed. That gap is real and I
confirmed it rather than assuming it: corrupting a level 2 block while leaving
the checkpoint untouched leaves the self checksum valid while the tree beneath
it is broken.

Closing it means verifying each reference's CRC-64 as the tree is walked, where
the parent-stored checksum is already in hand. I deliberately left that out of
this change to keep it reviewable, and because most level 1 children are not
identity-mapped and so cannot be resolved during an upfront sweep. I would be
glad to follow up with it, probably behind an option.

## Testing

| Case | Result |
|---|---|
| Clean volume | 2957 entries, no warnings, output byte-identical to before the change |
| Byte corrupted in the newer checkpoint block | rejected, falls back to the older generation, tree still fully readable |
| Corruption reverted | no warnings |
| FUSE mount | mounts read-only, warnings emitted once at mount rather than per operation |

## Notes

- Rebased onto current master (be38c97), so this is now a single commit. It
  previously carried a level 2 reference list offset fix as its first commit,
  which turned out to duplicate bb293da; #18 is closed accordingly. All the
  results below were re-measured on top of current master after the rebase, not
  carried over from the earlier branch.
- No tests are included. The tree has no unit test harness (`test/` holds a
  development utility rather than a suite), and introducing one alongside a
  functional change seemed out of scope. If you would like a known-answer check
  for the CRC, it is a small addition and I am happy to add it.
