### PR TITLE
Decimal/hex typo `&value[20]` in the duplicate object-table parser

### DIFF
--- a/librefs/node.c
+++ b/librefs/node.c
@@ -5019,7 +5019,7 @@ static int refs_node_parse_level2_0x4_leaf_value(
 			/* const u8 *base */
 			value,
 			/* const u8 *data */
-			&value[20]);
+			&value[0x20]);
 		i += 0x30;
 	}
 	if(value_size >= 0x58) {


### PR DESCRIPTION
In the parser for table `0x4` (the Object ID Table duplicate), the embedded node reference is
read from `&value[20]` — decimal 20 (= 0x14) — while every neighbouring offset in the file is written in hex,
the row accumulator advances by `i += 0x30` (`:5022`), and the analogous read in the primary object-table
parser uses value+0x20. The literal `20` is almost certainly meant to be `0x20`.